### PR TITLE
Fix actually getting the list of objects:

### DIFF
--- a/backend/src/business_objects/business_object_base.py
+++ b/backend/src/business_objects/business_object_base.py
@@ -182,7 +182,7 @@ class BOBase(BOBaseBase):
         raise NotImplementedError("count_rows not implemented")
 
     @classmethod
-    async def get_matching_ids(cls, conditions: dict | None = None) -> list[int]:
+    async def get_matching_ids(cls, conditions: dict = {}) -> list[int]:
         """Get the ids of business objects matching the conditions"""
         raise NotImplementedError("get_matching_ids not implemented")
 

--- a/backend/src/business_objects/persistant_business_object.py
+++ b/backend/src/business_objects/persistant_business_object.py
@@ -77,11 +77,12 @@ class PersistentBusinessObject(BOBase):
         return result["count"]
 
     @classmethod
-    async def get_matching_ids(cls, conditions: dict | None = None) -> list[int]:
+    async def get_matching_ids(cls, conditions: dict = {}) -> list[int]:
         """Get the ids of business objects matching the conditions"""
         async with SQL() as sql:
             select = sql.select(["id"]).from_(cls.table)
-            select.where(Filter(conditions))
+            if conditions != {}:
+                select.where(Filter(conditions))
             result = await (await select.execute()).fetchall()
         # LOG.debug(f"BOBase.get_matching_ids({conditions=}) -> {result=}")
         return [id["id"] for id in result]

--- a/backend/src/database/dbms/sqlite.py
+++ b/backend/src/database/dbms/sqlite.py
@@ -194,6 +194,9 @@ class SQLiteCursor(Cursor):
             await self._cursor.execute(sql=query, parameters=params)
             self._rowcount = self._cursor.rowcount
         except sqlite3.OperationalError as err:
+            LOG.error(
+                f"SQLiteCursor.execute: OperationalError while executing {query=}:"
+            )
             raise OperationalError(err)
         return self
 

--- a/backend/src/database/sql_expression.py
+++ b/backend/src/database/sql_expression.py
@@ -44,6 +44,10 @@ class SQLMultiExpression(SQLExpression):
             raise NotImplementedError(
                 "SQL_multi_expression is an abstract class and should not be instantiated."
             )
+        if not self._arguments or len(self._arguments) == 0:
+            raise ValueError(
+                f"SQL_multi_expression must have at least one argument, got {len(self._arguments)}"
+            )
         return (
             "("
             + re.sub(

--- a/backend/testing/persistance/test_business_object_base.py
+++ b/backend/testing/persistance/test_business_object_base.py
@@ -71,3 +71,9 @@ class Test_100_BOBase_classmethods(unittest.IsolatedAsyncioTestCase):
         print(f"{MockBO2.attribute_descriptions()=}")
         print(f"{mock_attr_desc=}")
         self.assertEqual(MockBO2.attribute_descriptions(), mock_attr_desc)
+
+    def test_106_get_business_object_by_name(self):
+        MockBO2.register_persistant_class()
+        self.assertEqual(BOBase.get_business_object_by_name("mockbo2"), MockBO2)
+        with self.assertRaises(ValueError):
+            BOBase.get_business_object_by_name("non_existent_bo")


### PR DESCRIPTION
After the last PR, object lists would crash their connections, because getting all matching ids resulted in an invalid SQL expression.l

- AND expression raises error if it has no arguments (previously it would produce the expression "()")
- bo doesn't add invalid WHERE clause if get_matching_ids is invoked without conditions (previously it would produce the expression SELECT id FROM ### WHERE (), which on sqlite raises an OperationalError on execution
- When an OperationalError is raised, the expression that caused the exception to be raised will be printed.