### PR TITLE
137-borelation-fields-should-be-shown-with-name

### DIFF
--- a/backend/src/business_objects/bo_descriptors.py
+++ b/backend/src/business_objects/bo_descriptors.py
@@ -351,6 +351,9 @@ class BORelation(_PersistantAttr[BOBaseBase]):
                 )
         if isinstance(value, int) and isinstance(relation, type):
             value = relation(bo_id=value)
+        if isinstance(value, dict):
+            if value.get("bo_type") == relation._name() and "id" in value:
+                value = relation(bo_id=value["id"])
         # LOG.debug(f"Setting BORelation to {repr(value)} (relation={relation})")
         super().__set__(obj=obj, value=value)
 

--- a/backend/src/business_objects/business_object_base.py
+++ b/backend/src/business_objects/business_object_base.py
@@ -119,9 +119,13 @@ class BOBase(BOBaseBase):
             else f"{self.__class__.__name__}(no id)"
         )
 
-    def json_encode(self) -> int | None:
+    def json_encode(self) -> dict | None:
         "Return a JSON-serializable representation of the business object"
-        return self.id if self.id is not None else None
+        return {
+            "bo_type": self._name(),
+            "id": self.id,
+            "display_name": self.display_name,
+        }
 
     @property
     def display_name(self) -> str:

--- a/backend/src/messages/message.py
+++ b/backend/src/messages/message.py
@@ -82,10 +82,18 @@ def json_encode(obj: Any) -> Any:
     return str(obj) if isinstance(obj, (datetime, date, pathlib.Path)) else obj
 
 
-def _serialize(msg_dict: dict) -> dict:
+async def _load_value(val):
+    "load content for business objects"
+    if hasattr(val, "fetch") and callable(getattr(val, "fetch")):
+        await val.fetch()
+    return val
+
+
+async def _serialize(msg_dict: dict) -> dict:
     "serialize a message dictionary replacing keys by str(key)"
     return {
-        str(k): _serialize(v) if isinstance(v, dict) else v for k, v in msg_dict.items()
+        str(k): await _serialize(v) if isinstance(v, dict) else await _load_value(v)
+        for k, v in msg_dict.items()
     }
 
 
@@ -161,10 +169,10 @@ class Message(BaseObject):
         "Add items to the message root that will be serialized and sent via websocket"
         self.message |= attrs
 
-    def serialize(self):
+    async def serialize(self):
         "Serialize to JSON"
         # LOG.debug(f"Message.serialize: message={self.message}")
-        return dumps(_serialize(self.message), default=json_encode)
+        return dumps(await _serialize(self.message), default=json_encode)
 
     async def handle_message(self, connection):
         "Handle unknown message type"

--- a/backend/src/server/ws_connection.py
+++ b/backend/src/server/ws_connection.py
@@ -106,7 +106,7 @@ class WSConnection(WSConnectionBase):
             message.add({MessageAttribute.WS_ATTR_STATUS: App.status})
         if not message.get_str(MessageAttribute.WS_ATTR_TOKEN):
             message.add({MessageAttribute.WS_ATTR_TOKEN: self._token})
-        await self._send(message.serialize())
+        await self._send(await message.serialize())
 
     async def send_message_to_component(self, comp, msg):
         """

--- a/backend/testing/messages/test_messages.py
+++ b/backend/testing/messages/test_messages.py
@@ -1,12 +1,14 @@
-""" Test suite for Message base class. """
+"""Test suite for Message base class."""
 
 import unittest
+from json import dumps, loads
+from unittest.mock import AsyncMock, MagicMock
 
 from messages.message import Message, MessageType, MessageAttribute
 
 
-class TestMessage(unittest.IsolatedAsyncioTestCase):
-    def test_001_message_from_empty_json(self):
+class Test_100_Message(unittest.IsolatedAsyncioTestCase):
+    def test_101_message_from_empty_json(self):
         message = Message("")
         self.assertIs(
             message.message[MessageAttribute.WS_ATTR_TYPE], MessageType.WS_TYPE_NONE
@@ -15,14 +17,14 @@ class TestMessage(unittest.IsolatedAsyncioTestCase):
         self.assertIs(message.message_type(), MessageType.WS_TYPE_NONE)
         self.assertIsNone(message.token)
 
-    def test_002_message_from_json_without_type(self):
+    def test_102_message_from_json_without_type(self):
         message = Message('{"text": "message without type attribute"}')
         self.assertIs(
             message.message[MessageAttribute.WS_ATTR_TYPE], MessageType.WS_TYPE_NONE
         )
         self.assertIs(message.message_type(), MessageType.WS_TYPE_NONE)
 
-    def test_002_message_from_json_with_unknown_type(self):
+    def test_103_message_from_json_with_unknown_type(self):
         unknown_test_type = "unknownTestType"
         message = Message(
             '{"type": "' + unknown_test_type + '", "text": "some attribute"}'
@@ -31,3 +33,181 @@ class TestMessage(unittest.IsolatedAsyncioTestCase):
             message.message[MessageAttribute.WS_ATTR_TYPE], unknown_test_type
         )
         self.assertIs(message.message_type(), MessageType.WS_TYPE_NONE)
+
+    def test_104_get_attributes(self):
+        message = Message(
+            dumps(
+                {
+                    MessageAttribute.WS_ATTR_TYPE: "testType",
+                    MessageAttribute.WS_ATTR_TOKEN: "mockToken",
+                    MessageAttribute.WS_ATTR_INDEX: 42,
+                    MessageAttribute.WS_ATTR_IS_PRIMARY: True,
+                    MessageAttribute.WS_ATTR_COMPONENT: "testComponent",
+                    MessageAttribute.WS_ATTR_PAYLOAD: {"key": "value"},
+                }
+            )
+        )
+        self.assertEqual(message.token, "mockToken")
+        self.assertEqual(
+            message.get_str(MessageAttribute.WS_ATTR_COMPONENT), "testComponent"
+        )
+        self.assertIsNone(message.get_str(MessageAttribute.WS_ATTR_INDEX))
+        self.assertEqual(message.get_int(MessageAttribute.WS_ATTR_INDEX), 42)
+        self.assertIsNone(message.get_int(MessageAttribute.WS_ATTR_COMPONENT))
+        self.assertEqual(
+            message.message[MessageAttribute.WS_ATTR_PAYLOAD], {"key": "value"}
+        )
+
+    def test_105_add_single_attribute(self):
+        message = Message()
+        message.add({MessageAttribute.WS_ATTR_PAYLOAD: {"test": "data"}})
+        self.assertEqual(
+            message.message[MessageAttribute.WS_ATTR_PAYLOAD], {"test": "data"}
+        )
+
+    def test_106_add_multiple_attributes(self):
+        message = Message()
+        message.add(
+            {
+                MessageAttribute.WS_ATTR_PAYLOAD: {"key": "value"},
+                MessageAttribute.WS_ATTR_STATUS: "success",
+                "custom_field": "custom_value",
+            }
+        )
+        self.assertEqual(
+            message.message[MessageAttribute.WS_ATTR_PAYLOAD], {"key": "value"}
+        )
+        self.assertEqual(message.message[MessageAttribute.WS_ATTR_STATUS], "success")
+        self.assertEqual(message.message["custom_field"], "custom_value")
+
+    def test_107_add_overwrites_existing_attributes(self):
+        message = Message(dumps({MessageAttribute.WS_ATTR_PAYLOAD: {"old": "data"}}))
+        message.add({MessageAttribute.WS_ATTR_PAYLOAD: {"new": "data"}})
+        self.assertEqual(
+            message.message[MessageAttribute.WS_ATTR_PAYLOAD], {"new": "data"}
+        )
+
+    def test_108_add_with_various_data_types(self):
+        message = Message()
+        message.add(
+            {
+                "string_field": "test string",
+                "int_field": 42,
+                "bool_field": True,
+                "list_field": [1, 2, 3],
+                "dict_field": {"nested": "value"},
+                "none_field": None,
+            }
+        )
+        self.assertEqual(message.message["string_field"], "test string")
+        self.assertEqual(message.message["int_field"], 42)
+        self.assertEqual(message.message["bool_field"], True)
+        self.assertEqual(message.message["list_field"], [1, 2, 3])
+        self.assertEqual(message.message["dict_field"], {"nested": "value"})
+        self.assertIsNone(message.message["none_field"])
+
+    async def test_109_serialize_basic_message(self):
+        message = Message()
+        serialized = await message.serialize()
+        self.assertIsInstance(serialized, str)
+        deserialized = loads(serialized)
+        self.assertEqual(deserialized[MessageAttribute.WS_ATTR_TYPE], "None")
+        self.assertIsNone(deserialized[MessageAttribute.WS_ATTR_TOKEN])
+
+    async def test_110_serialize_message_with_payload(self):
+        message = Message()
+        message.add({MessageAttribute.WS_ATTR_PAYLOAD: {"key": "value"}})
+        serialized = await message.serialize()
+        deserialized = loads(serialized)
+        self.assertEqual(
+            deserialized[MessageAttribute.WS_ATTR_PAYLOAD], {"key": "value"}
+        )
+
+    async def test_111_serialize_message_with_multiple_attributes(self):
+        message = Message()
+        message.add(
+            {
+                MessageAttribute.WS_ATTR_PAYLOAD: {"data": "test"},
+                MessageAttribute.WS_ATTR_STATUS: "pending",
+                "custom": "field",
+            }
+        )
+        serialized = await message.serialize()
+        deserialized = loads(serialized)
+        self.assertEqual(
+            deserialized[MessageAttribute.WS_ATTR_PAYLOAD], {"data": "test"}
+        )
+        self.assertEqual(deserialized[MessageAttribute.WS_ATTR_STATUS], "pending")
+        self.assertEqual(deserialized["custom"], "field")
+
+    async def test_112_serialize_preserves_json_structure(self):
+        original_dict = {
+            MessageAttribute.WS_ATTR_TYPE: "testType",
+            MessageAttribute.WS_ATTR_TOKEN: "token123",
+            MessageAttribute.WS_ATTR_PAYLOAD: {"nested": {"value": 123}},
+        }
+        message = Message(dumps(original_dict))
+        serialized = await message.serialize()
+        deserialized = loads(serialized)
+        self.assertEqual(deserialized[MessageAttribute.WS_ATTR_TYPE], "testType")
+        self.assertEqual(deserialized[MessageAttribute.WS_ATTR_TOKEN], "token123")
+        self.assertEqual(
+            deserialized[MessageAttribute.WS_ATTR_PAYLOAD], {"nested": {"value": 123}}
+        )
+
+    async def test_113_serialize_with_datetime(self):
+        from datetime import datetime
+
+        message = Message()
+        test_datetime = datetime(2024, 1, 15, 10, 30, 45)
+        message.add({"timestamp": test_datetime})
+        serialized = await message.serialize()
+        deserialized = loads(serialized)
+        # datetime is converted to string
+        self.assertIsInstance(deserialized["timestamp"], str)
+        self.assertIn("2024-01-15", deserialized["timestamp"])
+
+    async def test_114_serialize_with_date(self):
+        from datetime import date
+
+        message = Message()
+        test_date = date(2024, 1, 15)
+        message.add({"date_field": test_date})
+        serialized = await message.serialize()
+        deserialized = loads(serialized)
+        # date is converted to string
+        self.assertIsInstance(deserialized["date_field"], str)
+        self.assertIn("2024-01-15", deserialized["date_field"])
+
+    async def test_115_serialize_with_object_having_fetch_method(self):
+        message = Message()
+
+        # Create a mock object with a fetch method
+        mock_object = MagicMock()
+        mock_object.fetch = AsyncMock(return_value=None)
+        mock_object.json_encode = MagicMock(return_value={"mock": "data"})
+
+        message.add(
+            {
+                MessageAttribute.WS_ATTR_PAYLOAD: {
+                    "business_object": mock_object,
+                    "other_data": "value",
+                }
+            }
+        )
+
+        serialized = await message.serialize()
+
+        mock_object.fetch.assert_called_once_with()
+        self.assertIsInstance(serialized, str)
+        self.assertEqual(
+            loads(serialized),
+            {
+                "token": None,
+                "type": "None",
+                MessageAttribute.WS_ATTR_PAYLOAD: {
+                    "other_data": "value",
+                    "business_object": {"mock": "data"},
+                },
+            },
+        )

--- a/backend/testing/server/test_ws_connection.py
+++ b/backend/testing/server/test_ws_connection.py
@@ -29,7 +29,8 @@ class Test_100_WS_Connection(unittest.IsolatedAsyncioTestCase):
         self.connection._send = AsyncMock(name="_send")
         mock_message = Mock(name="message")
         mock_message.add = Mock()
-        mock_message.serialize = Mock()
+        mock_serialized = "mockSerializedMessage"
+        mock_message.serialize = AsyncMock(return_value=mock_serialized)
         if status is None:
             arg = {}
         else:
@@ -44,7 +45,7 @@ class Test_100_WS_Connection(unittest.IsolatedAsyncioTestCase):
             )
         else:
             mock_message.add.assert_not_called()
-        self.connection._send.assert_awaited_once_with(mock_message.serialize())
+        self.connection._send.assert_awaited_once_with(mock_serialized)
 
     async def test_102a_send_message_without_status(self):
         await self._102_send_message()


### PR DESCRIPTION
- add disply_name asynchronously when serializing bo