### PR TITLE
147 semantic meaning included in schema

### DIFF
--- a/backend/src/business_objects/bo_descriptors.py
+++ b/backend/src/business_objects/bo_descriptors.py
@@ -7,6 +7,7 @@ from datetime import date, datetime
 import sys
 from typing import Any
 
+from business_objects.bo_semantic_role import BOSemanticRole
 from business_objects.business_attribute_base import BaseFlag
 from core.app_logging import getLogger
 
@@ -59,6 +60,7 @@ class AttributeDescription:
     constraint_values: dict[str, Any]
     attribute_type: AttributeType
     access_level: AttributeAccessLevel
+    semantic_role: BOSemanticRole = BOSemanticRole.RAW
 
 
 class BOBaseBase:
@@ -72,6 +74,7 @@ class BOBaseBase:
         constraint_flag: BOColumnConstraint,
         attribute_type: AttributeType,
         access_level: AttributeAccessLevel = AttributeAccessLevel.AAL_READ_WRITE,
+        semantic_role: BOSemanticRole = BOSemanticRole.RAW,
         **flag_values,
     ):
         "Register an attribute in the business object descriptor"
@@ -96,11 +99,13 @@ class _PersistantAttr[T]:
         self,
         constraint: BOColumnConstraint = BOColumnConstraint.BOC_NONE,
         access_level: AttributeAccessLevel = AttributeAccessLevel.AAL_READ_WRITE,
+        semantic_role: BOSemanticRole | None = None,
         **constraint_values,
     ) -> None:
         self._constraint = constraint
         self._constraint_values = constraint_values
         self.my_name = None
+        self._semantic_role = semantic_role or BOSemanticRole.RAW
         self.access_level: AttributeAccessLevel = access_level
 
     @classmethod
@@ -113,6 +118,11 @@ class _PersistantAttr[T]:
     def data_type(cls):
         "Datatype of attribute"
         raise NotImplementedError
+
+    @property
+    def semantic_role(self) -> BOSemanticRole:
+        "Semantic role of attribute for frontend"
+        return self._semantic_role
 
     def __set_name__(self, owner, name):
         self.my_name = name
@@ -127,6 +137,7 @@ class _PersistantAttr[T]:
             self._constraint or BOColumnConstraint.BOC_NONE,
             attribute_type=self.__class__.attribute_type(),
             access_level=self.access_level,
+            semantic_role=self.semantic_role,
             **(self._constraint_values or {}),
         )
 

--- a/backend/src/business_objects/bo_semantic_role.py
+++ b/backend/src/business_objects/bo_semantic_role.py
@@ -1,0 +1,14 @@
+"""BOSemanticRole enumeration, which represents the semantic roles of business objects for the frontend."""
+
+from enum import StrEnum, auto
+
+
+class BOSemanticRole(StrEnum):
+    """Enumeration for the semantic roles of business objects for the frontend."""
+
+    RAW = (
+        auto()
+    )  # Raw data to be displayed as is as purely technical information, e.g. for debugging purposes
+    BONAME = (
+        auto()
+    )  # The name of the business object, to be displayed in the frontend as a human-readable identifier for the business object

--- a/backend/src/business_objects/business_object_base.py
+++ b/backend/src/business_objects/business_object_base.py
@@ -10,6 +10,7 @@ from typing import Any, Coroutine, Type, TypeAlias, Optional, Callable, Self
 import weakref
 
 
+from .bo_semantic_role import BOSemanticRole
 from core.util import _classproperty
 from core.app_logging import getLogger, log_exit, logging
 from core.app import App
@@ -149,6 +150,7 @@ class BOBase(BOBaseBase):
         constraint_flag: BOColumnConstraint,
         attribute_type: AttributeType,
         access_level: AttributeAccessLevel = AttributeAccessLevel.AAL_READ_WRITE,
+        semantic_role: BOSemanticRole = BOSemanticRole.RAW,
         **flag_values,
     ):
         if not cls._attributes.get(cls.__name__):
@@ -166,6 +168,7 @@ class BOBase(BOBaseBase):
                 constraint_values=flag_values,
                 access_level=access_level,
                 attribute_type=attribute_type,
+                semantic_role=semantic_role,
             )
         )
 

--- a/backend/src/data/management/ultimate_test_object.py
+++ b/backend/src/data/management/ultimate_test_object.py
@@ -6,6 +6,7 @@ from core.app_logging import getLogger, log_exit
 
 LOG = getLogger(__name__)
 
+from business_objects.bo_semantic_role import BOSemanticRole
 from business_objects.business_attribute_base import BaseFlag
 from business_objects.persistant_business_object import PersistentBusinessObject
 from business_objects.bo_descriptors import (
@@ -38,7 +39,7 @@ class UltimateRelatedTestObject(PersistentBusinessObject):
 class UltimateTestObject(PersistentBusinessObject):
     "Business Object with all possible attribute types for testing purposes"
 
-    name = BOStr()
+    name = BOStr(semantic_role=BOSemanticRole.BONAME)
     bo_int = BOInt()
     bo_str = BOStr()
     bo_datetime = BODatetime()

--- a/backend/src/messages/object_schema.py
+++ b/backend/src/messages/object_schema.py
@@ -78,6 +78,7 @@ class ObjectSchema(Message):
                 if v is not None
             },
             "access_level": str(attribute.access_level.value),
+            "semantic_role": str(attribute.semantic_role.value),
         }
 
     def generate_payload(

--- a/backend/testing/messages/test_object_schema.py
+++ b/backend/testing/messages/test_object_schema.py
@@ -66,6 +66,7 @@ class Test_100__ObjectSchema(unittest.TestCase):
                         k: (obj.constraint_values_representation(val))
                         for k, val in v.constraint_values.items()
                     },
+                    "semantic_role": v.semantic_role,
                 },
                 payload[v.name],
             )

--- a/backend/testing/persistance/test_bo_descriptors.py
+++ b/backend/testing/persistance/test_bo_descriptors.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, ANY
 
 import business_objects.bo_descriptors
 from business_objects.bo_descriptors import AttributeAccessLevel, BOSelf
+from business_objects.bo_semantic_role import BOSemanticRole
 
 
 class MockAttr(business_objects.bo_descriptors._PersistantAttr):
@@ -39,6 +40,7 @@ class MockBO:
         constraint_flag,
         attribute_type,
         access_level: AttributeAccessLevel = AttributeAccessLevel.AAL_READ_WRITE,
+        semantic_role: BOSemanticRole = BOSemanticRole.RAW,
         **flag_values,
     ):
         cls._add_attributes_args = (
@@ -47,11 +49,13 @@ class MockBO:
             constraint_flag,
             attribute_type,
             access_level,
+            semantic_role,
             flag_values,
         )
 
 
 class Test_100__PersistantAttr(unittest.TestCase):
+
     def test_101_initialization(self):
         self.assertEqual(MockBO("mick").mock_attr, "mick")
         print(f"{MockBO.__dict__['mock_attr'].__dict__=}")
@@ -73,6 +77,7 @@ class Test_100__PersistantAttr(unittest.TestCase):
                 business_objects.bo_descriptors.BOColumnConstraint.BOC_NONE,
                 business_objects.bo_descriptors.AttributeType.ATYPE_STR,
                 AttributeAccessLevel.AAL_READ_WRITE,
+                BOSemanticRole.RAW,
                 {},
             ),
         )
@@ -131,6 +136,7 @@ class MockObj(business_objects.bo_descriptors.BOBaseBase):
         constraint_flag,
         attribute_type,
         access_level=AttributeAccessLevel.AAL_READ_WRITE,
+        semantic_role=BOSemanticRole.RAW,
         **flag_values,
     ):
         cls._attributes["MockObj"].append(
@@ -140,6 +146,7 @@ class MockObj(business_objects.bo_descriptors.BOBaseBase):
                 constraint_flag,
                 attribute_type,
                 access_level,
+                semantic_role,
                 flag_values,
             )
         )
@@ -153,6 +160,7 @@ expected_attributes = {
             business_objects.bo_descriptors.BOColumnConstraint.BOC_PK_INC,
             business_objects.bo_descriptors.AttributeType.ATYPE_INT,
             AttributeAccessLevel.AAL_READ_WRITE,
+            BOSemanticRole.RAW,
             {},
         ),
         (
@@ -161,6 +169,7 @@ expected_attributes = {
             business_objects.bo_descriptors.BOColumnConstraint.BOC_NOT_NULL,
             business_objects.bo_descriptors.AttributeType.ATYPE_STR,
             AttributeAccessLevel.AAL_READ_WRITE,
+            BOSemanticRole.RAW,
             {},
         ),
         (
@@ -169,6 +178,7 @@ expected_attributes = {
             business_objects.bo_descriptors.BOColumnConstraint.BOC_DEFAULT_CURR,
             business_objects.bo_descriptors.AttributeType.ATYPE_DATETIME,
             AttributeAccessLevel.AAL_READ_WRITE,
+            BOSemanticRole.RAW,
             {},
         ),
         (
@@ -177,6 +187,7 @@ expected_attributes = {
             business_objects.bo_descriptors.BOColumnConstraint.BOC_NONE,
             business_objects.bo_descriptors.AttributeType.ATYPE_DATE,
             AttributeAccessLevel.AAL_READ_WRITE,
+            BOSemanticRole.RAW,
             {},
         ),
         (
@@ -185,6 +196,7 @@ expected_attributes = {
             business_objects.bo_descriptors.BOColumnConstraint.BOC_DEFAULT,
             business_objects.bo_descriptors.AttributeType.ATYPE_DICT,
             AttributeAccessLevel.AAL_READ_WRITE,
+            BOSemanticRole.RAW,
             {"default": {"a": 1, "b": 2}},
         ),
         (
@@ -193,6 +205,7 @@ expected_attributes = {
             business_objects.bo_descriptors.BOColumnConstraint.BOC_NONE,
             business_objects.bo_descriptors.AttributeType.ATYPE_LIST,
             AttributeAccessLevel.AAL_READ_WRITE,
+            BOSemanticRole.RAW,
             {},
         ),
         (
@@ -201,6 +214,7 @@ expected_attributes = {
             business_objects.bo_descriptors.BOColumnConstraint.BOC_FK,
             business_objects.bo_descriptors.AttributeType.ATYPE_RELATION,
             AttributeAccessLevel.AAL_READ_WRITE,
+            BOSemanticRole.RAW,
             {"relation": MockRel},
         ),
         (
@@ -209,6 +223,7 @@ expected_attributes = {
             business_objects.bo_descriptors.BOColumnConstraint.BOC_FK,
             business_objects.bo_descriptors.AttributeType.ATYPE_RELATION,
             AttributeAccessLevel.AAL_READ_WRITE,
+            BOSemanticRole.RAW,
             {"relation": ANY},
         ),
         (
@@ -217,6 +232,7 @@ expected_attributes = {
             business_objects.bo_descriptors.BOColumnConstraint.BOC_NONE,
             business_objects.bo_descriptors.AttributeType.ATYPE_FLAG,
             AttributeAccessLevel.AAL_READ_WRITE,
+            BOSemanticRole.RAW,
             {"flag_type": MockFlag},
         ),
     ]
@@ -229,6 +245,7 @@ class Test_200_BOAttributes(unittest.TestCase):
 
     def test_201_attributes(self):
         self.maxDiff = None
+
         self.assertEqual(self.mock_obj._attributes, expected_attributes)
         ix_of_rel_self_attr = 7
         self.assertEqual(
@@ -236,7 +253,7 @@ class Test_200_BOAttributes(unittest.TestCase):
             "rel_self_attr",
         )
         self.assertEqual(
-            self.mock_obj._attributes["MockObj"][ix_of_rel_self_attr][5]["relation"],
+            self.mock_obj._attributes["MockObj"][ix_of_rel_self_attr][6]["relation"],
             MockObj,
         )
 


### PR DESCRIPTION
This pull request introduces a new concept of "semantic role" for business object attributes, enabling the frontend to better understand and display attributes according to their intended meaning. The changes add a `BOSemanticRole` enum, propagate it through attribute definitions, serialization, and tests, and update related APIs and test cases accordingly.

**Semantic Role Support for Attributes**

* Added the `BOSemanticRole` enumeration in `bo_semantic_role.py` to represent the semantic roles of business object attributes for frontend consumption.
* Updated attribute descriptors (`AttributeDescription`, `_PersistantAttr`, etc.) and their constructors to include a `semantic_role` field, defaulting to `BOSemanticRole.RAW`. [[1]](diffhunk://#diff-47fe8210a336bc8907ddf01fc97dca4588b7aeb722fa86b26a2570c83c97fa53R63) [[2]](diffhunk://#diff-47fe8210a336bc8907ddf01fc97dca4588b7aeb722fa86b26a2570c83c97fa53R77) [[3]](diffhunk://#diff-47fe8210a336bc8907ddf01fc97dca4588b7aeb722fa86b26a2570c83c97fa53R102-R108) [[4]](diffhunk://#diff-47fe8210a336bc8907ddf01fc97dca4588b7aeb722fa86b26a2570c83c97fa53R122-R126) [[5]](diffhunk://#diff-47fe8210a336bc8907ddf01fc97dca4588b7aeb722fa86b26a2570c83c97fa53R140) [[6]](diffhunk://#diff-54e7b1dc0bb26112c8952aa215a81fa5ffdd58783bb12d0eb80feb7dcbf1962dR13) [[7]](diffhunk://#diff-54e7b1dc0bb26112c8952aa215a81fa5ffdd58783bb12d0eb80feb7dcbf1962dR153) [[8]](diffhunk://#diff-54e7b1dc0bb26112c8952aa215a81fa5ffdd58783bb12d0eb80feb7dcbf1962dR171)
* Modified attribute creation in business objects and test objects to specify the semantic role where appropriate (e.g., setting `name` to `BONAME` in `UltimateTestObject`). [[1]](diffhunk://#diff-abeefe465e7536bd60e33226c22df371ab29d32846da82698b7e5bbe14ac3216R9) [[2]](diffhunk://#diff-abeefe465e7536bd60e33226c22df371ab29d32846da82698b7e5bbe14ac3216L41-R42)

**API and Serialization Updates**

* Extended the attribute representation in the object schema API to include the `semantic_role` property, ensuring this information is available to the frontend.

**Testing Enhancements**

* Updated and extended tests in `test_bo_descriptors.py` to include the `semantic_role` parameter in attribute definitions and assertions, ensuring correctness throughout the attribute lifecycle. [[1]](diffhunk://#diff-01b881f7a27858968ea3e44661cc1575608bbc70eb382c6a14e4c064dd82b1efR11) [[2]](diffhunk://#diff-01b881f7a27858968ea3e44661cc1575608bbc70eb382c6a14e4c064dd82b1efR43) [[3]](diffhunk://#diff-01b881f7a27858968ea3e44661cc1575608bbc70eb382c6a14e4c064dd82b1efR52-R58) [[4]](diffhunk://#diff-01b881f7a27858968ea3e44661cc1575608bbc70eb382c6a14e4c064dd82b1efR80) [[5]](diffhunk://#diff-01b881f7a27858968ea3e44661cc1575608bbc70eb382c6a14e4c064dd82b1efR139) [[6]](diffhunk://#diff-01b881f7a27858968ea3e44661cc1575608bbc70eb382c6a14e4c064dd82b1efR149) [[7]](diffhunk://#diff-01b881f7a27858968ea3e44661cc1575608bbc70eb382c6a14e4c064dd82b1efR163) [[8]](diffhunk://#diff-01b881f7a27858968ea3e44661cc1575608bbc70eb382c6a14e4c064dd82b1efR172) [[9]](diffhunk://#diff-01b881f7a27858968ea3e44661cc1575608bbc70eb382c6a14e4c064dd82b1efR181) [[10]](diffhunk://#diff-01b881f7a27858968ea3e44661cc1575608bbc70eb382c6a14e4c064dd82b1efR190) [[11]](diffhunk://#diff-01b881f7a27858968ea3e44661cc1575608bbc70eb382c6a14e4c064dd82b1efR199) [[12]](diffhunk://#diff-01b881f7a27858968ea3e44661cc1575608bbc70eb382c6a14e4c064dd82b1efR208) [[13]](diffhunk://#diff-01b881f7a27858968ea3e44661cc1575608bbc70eb382c6a14e4c064dd82b1efR217) [[14]](diffhunk://#diff-01b881f7a27858968ea3e44661cc1575608bbc70eb382c6a14e4c064dd82b1efR226) [[15]](diffhunk://#diff-01b881f7a27858968ea3e44661cc1575608bbc70eb382c6a14e4c064dd82b1efR235) [[16]](diffhunk://#diff-01b881f7a27858968ea3e44661cc1575608bbc70eb382c6a14e4c064dd82b1efR248-R256)
* Adjusted test assertions to account for the new position of the `relation` field in the attribute tuple due to the added `semantic_role`.

**Other Minor Updates**

* Updated imports in affected files to include the new `BOSemanticRole` enum. [[1]](diffhunk://#diff-47fe8210a336bc8907ddf01fc97dca4588b7aeb722fa86b26a2570c83c97fa53R10) [[2]](diffhunk://#diff-abeefe465e7536bd60e33226c22df371ab29d32846da82698b7e5bbe14ac3216R9) [[3]](diffhunk://#diff-01b881f7a27858968ea3e44661cc1575608bbc70eb382c6a14e4c064dd82b1efR11)

These changes lay the groundwork for more semantically aware frontend displays and improved attribute metadata handling across the backend and API.